### PR TITLE
Updated CLI commands and Zero Downtime Deployment

### DIFF
--- a/MageMojo.php
+++ b/MageMojo.php
@@ -28,7 +28,7 @@ task('mm:zdd:init', function () {
 
 desc('Zero Downtime Deployment Switch');
 task('mm:zdd:switch', function () {
-    run("{{stratus_cli}} zerodowntime.switch 2>&1 | grep -q 'ERROR' && echo "[ERROR] Something went wrong, waiting and repeating switch one more time" && sleep 120 && /usr/share/stratus/cli zerodowntime.switch || echo "[SUCCESS]"");
+    run("{{stratus_cli}} zerodowntime.switch 2>&1 | grep -q \'ERROR\' && echo \"[ERROR] Something went wrong, waiting and repeating switch one more time\" && sleep 120 && /usr/share/stratus/cli zerodowntime.switch || echo \"[SUCCESS]\"");
 });
 
 desc('It will issue a redeploy of PHP-FPM services');

--- a/MageMojo.php
+++ b/MageMojo.php
@@ -11,9 +11,29 @@ namespace Deployer;
 
 set('stratus_cli', '/usr/share/stratus/cli');
 
+desc('Stop Crons');
+task('mm:cron:stop', function () {
+    run("{{stratus_cli}} crons.stop");
+});
+
+desc('Start Crons');
+task('mm:cron:start', function () {
+    run("{{stratus_cli}} crons.start");
+});
+
+desc('Zero Downtime Deployment Init');
+task('mm:zdd:init', function () {
+    run("{{stratus_cli}} zerodowntime.init");
+});
+
+desc('Zero Downtime Deployment Switch');
+task('mm:zdd:switch', function () {
+    run("{{stratus_cli}} zerodowntime.switch 2>&1 | grep -q 'ERROR' && echo "[ERROR] Something went wrong, waiting and repeating switch one more time" && sleep 120 && /usr/share/stratus/cli zerodowntime.switch || echo "[SUCCESS]"");
+});
+
 desc('It will issue a redeploy of PHP-FPM services');
 task('mm:autoscaling:reinit', function () {
-    run("{{stratus_cli}} autoscaling.reinit");
+    run("{{stratus_cli}} autoscaling.reinit && sleep 120s");
 });
 
 desc('Clears everything');

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ You can run the command followed by **dep**. Example: `dep mm:cache:clear --stag
 
 | Command | Description |
 |----------|-------------|
+| mm:cron:stop | Stop Crons from running |
+| mm:cron:start | Start crons |
+| mm:zdd:init | Zero Downtime Deployment Init |
+| mm:zdd:switch | Zero Downtime Deployment Switch with check |
 | mm:autoscaling:reinit | It will issue a redeploy of PHP-FPM services |
 | mm:cache:clear | Clears everything |
 | mm:cloudfront:clear | Clears Cloudfront cache |


### PR DESCRIPTION
Hello Rafael,

I've added few commands to the deployer-magemojo tool including Zero Downtime deployment commands (init and switch) with a checker on the switch if state completes or not. 

Best regards,
Nemanja